### PR TITLE
Fixing broken link in the introduction

### DIFF
--- a/arrow-docs/docs/datatypes/intro/README.md
+++ b/arrow-docs/docs/datatypes/intro/README.md
@@ -34,7 +34,7 @@ The implementation of `fold()` is a simple `when` that checks whether `this` is 
 
 All other functions provided by `Option` are implemented by using `fold()`, making for idiomatic helper functions like `getOrNull`, `getOrElse`, or `map`. These functions work for any value of `A` and `B`. This way, what `Option` does for each individual case of `String`, `Int`, or absence is up to the functions passed by the user.
 
-Feel free to explore the [implementation of `Option`](https://github.com/arrow-kt/arrow-core/blob/master/arrow-core/arrow-core/src/main/kotlin/arrow/core/extensions/option.kt) and [other datatypes](https://github.com/arrow-kt/arrow/tree/master/modules/core/arrow-core-data/src/main/kotlin/arrow/core) to discover their behavior!
+Feel free to explore the [implementation of `Option`](https://github.com/arrow-kt/arrow-core/blob/master/arrow-core/src/main/kotlin/arrow/core/extensions/option.kt) and [other datatypes](https://github.com/arrow-kt/arrow/tree/master/modules/core/arrow-core-data/src/main/kotlin/arrow/core) to discover their behavior!
 
 ### Datatypes in Arrow
 


### PR DESCRIPTION
The current documentation sends to a wrong link for the implementation of `Option`. 

Simply removing the part of the URL should fix it.